### PR TITLE
Add HDR registry settings and fix console UTF-8 output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.vs/
+x64/
+unlockfps/x64/
+*.user
+*.suo
+*.obj
+*.pdb
+*.ilk
+*.log
+*.tlog
+*.idb
+*.recipe

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ ver 6.6 未有新的更新 直接用最新release即可。
 - 若缺少hide项启动游戏会自动写入hide=0(显示窗口)
 - 修改hide=1后不会显示窗口直接启动游戏
 
+**HDR（参考 Starward 方案，写入游戏注册表）**
+- 在 `fps_config.ini` 的 `[Setting]` 中配置（启动游戏前自动写入注册表）：
+  - `hdr=1` 开启 / `hdr=0` 关闭
+  - `hdr_max` 峰值亮度（300–2000，默认 1000）
+  - `hdr_scene` 场景亮度（100–500，默认 300）
+  - `hdr_ui` UI 亮度（150–550，默认 350）
+- 需显示器支持 HDR，并在 Windows 显示设置中开启 HDR；多显示器时请将 HDR 显示器设为主屏
+
 **若您觉得好用的话，请给winTEuser老哥的版本
 （[点我进入](https://github.com/winTEuser/Genshin_StarRail_fps_unlocker/releases)），点上star进行支持**
  - **要是觉得本项目挺好用的话，也可以点个star支持一下**

--- a/unlockfps/game_registry.cpp
+++ b/unlockfps/game_registry.cpp
@@ -1,0 +1,269 @@
+#include "game_registry.h"
+
+#include <Windows.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace
+{
+    constexpr const char* kHdrOnValueName = "WINDOWS_HDR_ON_h3132281285";
+    constexpr const char* kGeneralDataValueName = "GENERAL_DATA_h2389025596";
+    constexpr const char* kGlobalSubKey = "Software\\miHoYo\\Genshin Impact";
+    constexpr const char* kCnSubKey = "Software\\miHoYo\\\xe5\x8e\x9f\xe7\xa5\x9e"; // 原神
+
+    std::wstring Utf8ToWide(const std::string& utf8)
+    {
+        if (utf8.empty())
+            return {};
+
+        const int len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), static_cast<int>(utf8.size()), nullptr, 0);
+        if (len <= 0)
+            return {};
+
+        std::wstring wide(static_cast<size_t>(len), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), static_cast<int>(utf8.size()), wide.data(), len);
+        return wide;
+    }
+
+    std::string GetExeFileName(const std::string& gameExePath)
+    {
+        const size_t pos = gameExePath.find_last_of("\\/");
+        if (pos == std::string::npos)
+            return gameExePath;
+        return gameExePath.substr(pos + 1);
+    }
+
+    bool EqualsIgnoreCase(const std::string& a, const std::string& b)
+    {
+        if (a.size() != b.size())
+            return false;
+        for (size_t i = 0; i < a.size(); ++i)
+        {
+            if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i])))
+                return false;
+        }
+        return true;
+    }
+
+    bool RegGetBinary(HKEY key, const wchar_t* valueName, std::vector<BYTE>* out)
+    {
+        DWORD type = 0;
+        DWORD size = 0;
+        const LONG query = RegQueryValueExW(key, valueName, nullptr, &type, nullptr, &size);
+        if (query == ERROR_FILE_NOT_FOUND)
+        {
+            out->clear();
+            return true;
+        }
+        if (query != ERROR_SUCCESS || type != REG_BINARY || size == 0)
+            return false;
+
+        out->resize(size);
+        return RegQueryValueExW(key, valueName, nullptr, &type, out->data(), &size) == ERROR_SUCCESS;
+    }
+
+    bool RegSetBinary(HKEY key, const wchar_t* valueName, const std::vector<BYTE>& data)
+    {
+        return RegSetValueExW(
+                   key,
+                   valueName,
+                   0,
+                   REG_BINARY,
+                   data.empty() ? nullptr : data.data(),
+                   static_cast<DWORD>(data.size())) == ERROR_SUCCESS;
+    }
+
+    bool RegSetDword(HKEY key, const wchar_t* valueName, DWORD value)
+    {
+        return RegSetValueExW(key, valueName, 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value)) == ERROR_SUCCESS;
+    }
+
+    std::string TrimJsonPadding(const std::vector<BYTE>& data)
+    {
+        if (data.empty())
+            return {};
+
+        size_t end = data.size();
+        while (end > 0 && data[end - 1] == 0)
+            --end;
+
+        return std::string(reinterpret_cast<const char*>(data.data()), end);
+    }
+
+    bool TryReplaceJsonNumber(std::string& json, const std::string& key, int value)
+    {
+        const std::string quoted = "\"" + key + "\"";
+        const size_t keyPos = json.find(quoted);
+        if (keyPos == std::string::npos)
+            return false;
+
+        size_t colon = json.find(':', keyPos + quoted.size());
+        if (colon == std::string::npos)
+            return false;
+
+        size_t i = colon + 1;
+        while (i < json.size() && (json[i] == ' ' || json[i] == '\t' || json[i] == '\r' || json[i] == '\n'))
+            ++i;
+
+        const size_t start = i;
+        if (i < json.size() && (json[i] == '-' || json[i] == '+'))
+            ++i;
+
+        bool hasDigit = false;
+        while (i < json.size() && (std::isdigit(static_cast<unsigned char>(json[i])) || json[i] == '.'))
+        {
+            hasDigit = true;
+            ++i;
+        }
+        if (!hasDigit)
+            return false;
+
+        json.replace(start, i - start, std::to_string(value));
+        return true;
+    }
+
+    void InsertJsonField(std::string& json, const std::string& key, int value)
+    {
+        const std::string field = "\"" + key + "\":" + std::to_string(value);
+        const size_t close = json.rfind('}');
+        if (close == std::string::npos || json.find('{') == std::string::npos)
+        {
+            json = "{" + field + "}";
+            return;
+        }
+
+        size_t pos = close;
+        while (pos > 0 && (json[pos - 1] == ' ' || json[pos - 1] == '\t' || json[pos - 1] == '\r' || json[pos - 1] == '\n'))
+            --pos;
+
+        const bool hasContent = json.find_first_not_of(" \t\r\n{", 0) < pos;
+        if (hasContent)
+            json.insert(pos, "," + field);
+        else
+            json.insert(pos, field);
+    }
+
+    void EnsureJsonField(std::string& json, const std::string& key, int value)
+    {
+        if (!TryReplaceJsonNumber(json, key, value))
+            InsertJsonField(json, key, value);
+    }
+
+    std::string BuildGeneralDataJson(int maxLuminance, int sceneLuminance, int uiLuminance, const std::vector<BYTE>& existing)
+    {
+        std::string json = TrimJsonPadding(existing);
+        if (json.empty())
+        {
+            return "{\"maxLuminosity\":" + std::to_string(maxLuminance) +
+                   ",\"scenePaperWhite\":" + std::to_string(sceneLuminance) +
+                   ",\"uiPaperWhite\":" + std::to_string(uiLuminance) + "}";
+        }
+
+        EnsureJsonField(json, "maxLuminosity", maxLuminance);
+        EnsureJsonField(json, "scenePaperWhite", sceneLuminance);
+        EnsureJsonField(json, "uiPaperWhite", uiLuminance);
+        return json;
+    }
+
+    std::vector<BYTE> EncodeGeneralDataBlob(const std::string& json)
+    {
+        std::vector<BYTE> blob(json.begin(), json.end());
+        blob.push_back(0);
+        return blob;
+    }
+}
+
+GenshinHdrSettings ClampGenshinHdrSettings(GenshinHdrSettings settings)
+{
+    settings.maxLuminance = std::clamp(settings.maxLuminance, 300, 2000);
+    settings.sceneLuminance = std::clamp(settings.sceneLuminance, 100, 500);
+    settings.uiLuminance = std::clamp(settings.uiLuminance, 150, 550);
+    return settings;
+}
+
+std::string GetGenshinRegistrySubKey(const std::string& gameExePath)
+{
+    const std::string exe = GetExeFileName(gameExePath);
+    if (EqualsIgnoreCase(exe, "GenshinImpact.exe"))
+        return kGlobalSubKey;
+    return kCnSubKey;
+}
+
+bool ApplyGenshinHdrSettings(const std::string& gameExePath, const GenshinHdrSettings& settings, std::string* errorOut)
+{
+    if (errorOut)
+        errorOut->clear();
+
+    if (gameExePath.empty())
+    {
+        if (errorOut)
+            *errorOut = "game path is empty";
+        return false;
+    }
+
+    const GenshinHdrSettings hdr = ClampGenshinHdrSettings(settings);
+    const std::wstring subKey = Utf8ToWide(GetGenshinRegistrySubKey(gameExePath));
+    const std::wstring hdrOnName = Utf8ToWide(kHdrOnValueName);
+    const std::wstring generalDataName = Utf8ToWide(kGeneralDataValueName);
+
+    HKEY key = nullptr;
+    LONG openResult = RegOpenKeyExW(HKEY_CURRENT_USER, subKey.c_str(), 0, KEY_READ | KEY_WRITE, &key);
+    if (openResult == ERROR_FILE_NOT_FOUND)
+    {
+        openResult = RegCreateKeyExW(
+            HKEY_CURRENT_USER,
+            subKey.c_str(),
+            0,
+            nullptr,
+            REG_OPTION_NON_VOLATILE,
+            KEY_READ | KEY_WRITE,
+            nullptr,
+            &key,
+            nullptr);
+    }
+
+    if (openResult != ERROR_SUCCESS || !key)
+    {
+        if (errorOut)
+            *errorOut = "failed to open registry key (" + std::to_string(openResult) + ")";
+        return false;
+    }
+
+    bool ok = true;
+    std::string stepError;
+
+    if (!RegSetDword(key, hdrOnName.c_str(), hdr.enable ? 1u : 0u))
+    {
+        ok = false;
+        stepError = "failed to write HDR switch";
+    }
+
+    std::vector<BYTE> existing;
+    if (ok && !RegGetBinary(key, generalDataName.c_str(), &existing))
+    {
+        ok = false;
+        stepError = "failed to read GENERAL_DATA";
+    }
+
+    if (ok)
+    {
+        const std::string json = BuildGeneralDataJson(hdr.maxLuminance, hdr.sceneLuminance, hdr.uiLuminance, existing);
+        const std::vector<BYTE> blob = EncodeGeneralDataBlob(json);
+        if (!RegSetBinary(key, generalDataName.c_str(), blob))
+        {
+            ok = false;
+            stepError = "failed to write GENERAL_DATA";
+        }
+    }
+
+    RegCloseKey(key);
+
+    if (!ok && errorOut)
+        *errorOut = stepError;
+
+    return ok;
+}

--- a/unlockfps/game_registry.h
+++ b/unlockfps/game_registry.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+struct GenshinHdrSettings
+{
+    bool enable = false;
+    int maxLuminance = 1000;
+    int sceneLuminance = 300;
+    int uiLuminance = 350;
+};
+
+GenshinHdrSettings ClampGenshinHdrSettings(GenshinHdrSettings settings);
+
+// Registry subkey under HKCU, e.g. Software\miHoYo\原神
+std::string GetGenshinRegistrySubKey(const std::string& gameExePath);
+
+// Writes WINDOWS_HDR_ON and GENERAL_DATA luminance fields (Starward-compatible).
+bool ApplyGenshinHdrSettings(const std::string& gameExePath, const GenshinHdrSettings& settings, std::string* errorOut);

--- a/unlockfps/main.cpp
+++ b/unlockfps/main.cpp
@@ -12,11 +12,16 @@
 #include <thread>
 #include <Psapi.h>
 #include "inireader.h"
+#include "game_registry.h"
 
 std::string GamePath{};
 int FpsValue = FPS_TARGET;
 int HideValue = 0;
 bool ShowConsole = true;
+bool HdrEnable = false;
+int HdrMax = 1000;
+int HdrScene = 300;
+int HdrUi = 350;
 
 DWORD StartPriority = 0;
 const std::vector<DWORD> PrioityClass = {
@@ -247,7 +252,11 @@ bool WriteConfig(std::string GamePath, int fps)
     content = "[Setting]\n";
     content += "Path=" + GamePath + "\n";
     content += "FPS=" + std::to_string(fps) + "\n";
-    content += "hide=" + std::to_string(HideValue);
+    content += "hide=" + std::to_string(HideValue) + "\n";
+    content += "hdr=" + std::to_string(HdrEnable ? 1 : 0) + "\n";
+    content += "hdr_max=" + std::to_string(HdrMax) + "\n";
+    content += "hdr_scene=" + std::to_string(HdrScene) + "\n";
+    content += "hdr_ui=" + std::to_string(HdrUi);
 
     DWORD written = 0;
     WriteFile(hFile, content.data(), content.size(), &written, nullptr);
@@ -262,6 +271,20 @@ void ApplyConsoleVisibility()
         return;
 
     ShowWindow(hConsole, ShowConsole ? SW_SHOW : SW_HIDE);
+}
+
+static void InitConsoleUtf8()
+{
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+
+    const HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE)
+        return;
+
+    DWORD mode = 0;
+    if (GetConsoleMode(hOut, &mode))
+        SetConsoleMode(hOut, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 }
 
 //Hotpatch - 注入shellcode到游戏进程
@@ -390,6 +413,16 @@ void LoadConfig()
         HideValue = reader.GetInteger("Setting", "hide", HideValue);
     }
     ShowConsole = (HideValue == 0);
+    HdrEnable = reader.GetBoolean("Setting", "hdr", HdrEnable);
+    HdrMax = static_cast<int>(reader.GetInteger("Setting", "hdr_max", HdrMax));
+    HdrScene = static_cast<int>(reader.GetInteger("Setting", "hdr_scene", HdrScene));
+    HdrUi = static_cast<int>(reader.GetInteger("Setting", "hdr_ui", HdrUi));
+    {
+        const GenshinHdrSettings clamped = ClampGenshinHdrSettings({ HdrEnable, HdrMax, HdrScene, HdrUi });
+        HdrMax = clamped.maxLuminance;
+        HdrScene = clamped.sceneLuminance;
+        HdrUi = clamped.uiLuminance;
+    }
 
     if (GetFileAttributesA(GamePath.c_str()) == INVALID_FILE_ATTRIBUTES)
     {
@@ -450,6 +483,8 @@ DWORD __stdcall Thread1(LPVOID p)
 }
 int main(int argc, char** argv)
 {
+    InitConsoleUtf8();
+
     std::atexit([] {
         if (ShowConsole)
             system("pause");
@@ -476,9 +511,18 @@ int main(int argc, char** argv)
 
     printf("FPS解锁 好用的话点个star吧 6.3\n");
     printf("https://github.com/xiaonian233/genshin-fps-unlock \n特别感谢winTEuser老哥 \n");
-    printf("游戏路径: %s\n\n", ProcessPath.c_str());
+    printf("游戏路径: %s\n", ProcessPath.c_str());
+    printf("HDR: %s (max=%d scene=%d ui=%d)\n\n",
+        HdrEnable ? "ON" : "OFF", HdrMax, HdrScene, HdrUi);
     ProcessDir = ProcessPath.substr(0, ProcessPath.find_last_of("\\"));
     std::string procname = ProcessPath.substr(ProcessPath.find_last_of("\\") + 1);
+
+    {
+        GenshinHdrSettings hdrSettings{ HdrEnable, HdrMax, HdrScene, HdrUi };
+        std::string hdrError;
+        if (!ApplyGenshinHdrSettings(ProcessPath, hdrSettings, &hdrError))
+            printf("HDR 设置写入失败: %s\n", hdrError.c_str());
+    }
 
     DWORD pid = GetPID(procname);
     if (pid)

--- a/unlockfps/unlockfps.vcxproj
+++ b/unlockfps/unlockfps.vcxproj
@@ -88,6 +88,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -102,6 +103,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,6 +120,7 @@
       <ConformanceMode>true</ConformanceMode>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,7 +138,7 @@
       <ConformanceMode>true</ConformanceMode>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalOptions>/source-charset:utf-8 /execution-charset:.936 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,6 +149,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="game_registry.cpp" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/unlockfps/unlockfps.vcxproj.filters
+++ b/unlockfps/unlockfps.vcxproj.filters
@@ -15,9 +15,17 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="game_registry.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="game_registry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />


### PR DESCRIPTION
Write Genshin HDR switch and luminance values before launch (Starward-compatible), extend fps_config.ini, unify /utf-8 build flags, and ignore VS build artifacts.

（新增了 HDR 的实现，不过可能与本工具主功能有所背离，可根据实际需求决定是否合并）